### PR TITLE
重命名服务器配置文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## 如何开始
 
-> **配置`/walk-view/src/config/Server.ts`**
+> **配置`/walk-view/src/config/server.ts`**
 
 **本地运行测试**
 

--- a/src/components/message/MessageItem.vue
+++ b/src/components/message/MessageItem.vue
@@ -2,7 +2,7 @@
 import axios from 'axios'
 import { NCard, NButton, useMessage } from 'naive-ui'
 import { useRouter } from 'vue-router'
-import Server from '../../config/Server'
+import Server from '../../config/server'
 
 const messagePrompt = useMessage()
 const router = useRouter()

--- a/src/components/team/CreateTeam.vue
+++ b/src/components/team/CreateTeam.vue
@@ -17,7 +17,7 @@ import {
 import { SelectMixedOption } from 'naive-ui/lib/select/src/interface'
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import Config from '../../config/Server'
+import Config from '../../config/server'
 
 let routeOptions = ref<SelectMixedOption[]>()
 let formRef = ref<FormInst | null>(null)

--- a/src/components/team/UpdateTeam.vue
+++ b/src/components/team/UpdateTeam.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import axios, { AxiosResponse } from 'axios'
-import Config from '../../config/Server'
+import Config from '../../config/server'
 import {
   NCard,
   NForm,

--- a/src/components/team/join/PasswordJoin.vue
+++ b/src/components/team/join/PasswordJoin.vue
@@ -8,7 +8,7 @@ import {
 } from 'naive-ui';
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
-import ServerConfig from '../../../config/Server';
+import ServerConfig from '../../../config/server';
 
 const router = useRouter();
 const teamID = ref('');

--- a/src/components/team/join/RandomJoin.vue
+++ b/src/components/team/join/RandomJoin.vue
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { NSelect, NButton, NSpace, NGrid, NGridItem, useMessage, NModal } from 'naive-ui'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import ServerConfig from '../../../config/Server'
+import ServerConfig from '../../../config/server'
 import RandomList from './RandomList.vue'
 
 const router = useRouter()

--- a/src/components/team/join/TeamItem.vue
+++ b/src/components/team/join/TeamItem.vue
@@ -2,7 +2,7 @@
 import axios from 'axios'
 import { NThing, NTag, NCard, NButton, useMessage } from 'naive-ui'
 import { useRouter } from 'vue-router'
-import Server from '../../../config/Server'
+import Server from '../../../config/server'
 
 const router = useRouter()
 const message = useMessage()

--- a/src/components/team/manage/ManageMemberCard.vue
+++ b/src/components/team/manage/ManageMemberCard.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { NSpace, NButton, NCard, useMessage } from 'naive-ui'
-import ServerConfig from '../../../config/Server'
 import axios from 'axios'
 import { useRouter } from 'vue-router'
-import Server from '../../../config/Server'
+import Server from '../../../config/server'
 
 const message = useMessage()
 const router = useRouter()
@@ -15,7 +14,7 @@ defineProps({
 })
 
 function removeMember(openID: string | undefined) {
-  const removeMemberUrl = ServerConfig.urlPrefix + ServerConfig.apiMap['team']['remove']
+  const removeMemberUrl = Server.urlPrefix + Server.apiMap['team']['remove']
   axios
     .get(removeMemberUrl, {
       params: {

--- a/src/components/team/show/TeamInfoButtons.vue
+++ b/src/components/team/show/TeamInfoButtons.vue
@@ -3,7 +3,7 @@ import axios, { AxiosResponse } from 'axios'
 import { NButton, useMessage, useDialog } from 'naive-ui'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import ServerConfig from '../../../config/Server'
+import ServerConfig from '../../../config/server'
 import { getTeamData, getUserData } from '../../../utility'
 
 const router = useRouter()

--- a/src/components/user/register/RegisterStudentInfo.vue
+++ b/src/components/user/register/RegisterStudentInfo.vue
@@ -11,7 +11,7 @@ import {
   NSelect,
 } from 'naive-ui';
 import { SelectMixedOption } from 'naive-ui/lib/select/src/interface';
-import Server from '../../../config/Server';
+import Server from '../../../config/server';
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 

--- a/src/components/user/register/RegisterTeacherInfo.vue
+++ b/src/components/user/register/RegisterTeacherInfo.vue
@@ -10,7 +10,7 @@ import {
   useMessage,
 } from 'naive-ui';
 import { ref } from 'vue';
-import Server from '../../../config/Server';
+import Server from '../../../config/server';
 import axios, { AxiosResponse } from 'axios';
 import { useRouter } from 'vue-router';
 

--- a/src/components/user/update/UpdateStudentInfo.vue
+++ b/src/components/user/update/UpdateStudentInfo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { NSpace, NSelect } from 'naive-ui'
 import { SelectMixedOption } from 'naive-ui/lib/select/src/interface'
-import Server from '../../../config/Server'
+import Server from '../../../config/server'
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import axios, { Axios, AxiosResponse } from 'axios'

--- a/src/components/user/update/UpdateTeacherInfo.vue
+++ b/src/components/user/update/UpdateTeacherInfo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Server from '../../../config/Server'
+import Server from '../../../config/server'
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { getUserData } from '../../../utility'

--- a/src/pages/Loading.vue
+++ b/src/pages/Loading.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { NSpace, NSpin, useDialog } from 'naive-ui'
-import Server from '../config/Server'
+import Server from '../config/server'
 import axios from 'axios'
 import { useRouter } from 'vue-router'
 import { onMounted } from 'vue'

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { NSpace, NSpin } from 'naive-ui'
 import { useRouter } from 'vue-router'
-import Server from '../config/Server'
+import Server from '../config/server'
 import { onMounted } from '@vue/runtime-core'
 import { getQueryVariable } from '../utility'
 

--- a/src/pages/Poster.vue
+++ b/src/pages/Poster.vue
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { NPageHeader, NCard, NAlert, NSpin, useMessage , NButton } from 'naive-ui'
 import { onMounted, ref , nextTick} from 'vue'
 import { useRouter } from 'vue-router'
-import server from '../config/Server'
+import server from '../config/server'
 import html2canvas from 'html2canvas'
 import { type } from 'os'
 import b1 from "../assets/b1.png"

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,4 +1,4 @@
-import Server from './config/Server'
+import Server from './config/server'
 import axios from 'axios'
 
 export function getQueryVariable(variable: string): string {


### PR DESCRIPTION
原来文件名没区分大小写，引用的地方都是首字母大写 `Server`，但是样例文件是小写 `src/config/server.example.ts`。

现在统一为首字母小写 `server.ts`